### PR TITLE
changes for running headless CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ At any time, you can pull changes from the upstream and merge them onto your mas
 The general idea is to keep your 'master' branch in-sync with the
 'upstream/master'.
 
+## Setup your environment
+
+Setup your local environment with Maven 3.2.x+. See the [Maven local settings.xml](https://developer.jboss.org/wiki/MavenGettingStarted-Developers) for set up of jboss.org repository.
+
 ## Building
 
 This project depends on [jbosstools-base](https://github.com/jbosstools/jbosstools-base) and [jbosstools-forge](https://github.com/jbosstools/jbosstools-forge). 

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
         <groupId>org.jboss.tools</groupId>
         <artifactId>parent</artifactId>
         <version>4.4.1.Alpha1-SNAPSHOT</version>
+        <relativePath/>
     </parent>
 
     <artifactId>windup</artifactId>

--- a/tests/org.jboss.tools.windup.core.test/src/org/jboss/tools/windup/core/test/WindupTest.java
+++ b/tests/org.jboss.tools.windup.core.test/src/org/jboss/tools/windup/core/test/WindupTest.java
@@ -19,16 +19,24 @@ import org.eclipse.ui.PlatformUI;
 import org.jboss.tools.windup.core.services.WindupService;
 import org.junit.Before;
 
+import org.junit.Assert;
+
 public class WindupTest {
 	
 	@Inject	protected WindupService windupService;
 	
 	@Before
 	public void setup() {
+		if ( getContext() == null ) {
+			Assert.fail("Could not get Eclipse workbench as a context for running tests!");
+		}
 		ContextInjectionFactory.inject(this, getContext());
 	}
 	
 	private IEclipseContext getContext() {
+		if (!PlatformUI.isWorkbenchRunning()) {
+			return null;
+		}
 		return PlatformUI.getWorkbench().getService(MApplication.class).getContext().getActiveLeaf();
 	}
 }

--- a/tests/org.jboss.tools.windup.core.test/src/org/jboss/tools/windup/core/test/WindupValidatorTest.java
+++ b/tests/org.jboss.tools.windup.core.test/src/org/jboss/tools/windup/core/test/WindupValidatorTest.java
@@ -27,7 +27,7 @@ import org.jboss.tools.test.util.TestProjectProvider;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 public class WindupValidatorTest extends WindupTest
 {


### PR DESCRIPTION
Even I still need to disable running tests with `-Dmaven.test.skip` the build should pass now.

There is addition to WindupTest to check if workbench is setup, if not it will fail and should show the error in test log