### PR TITLE
WINDUP-1169 - Added update mechanism to marker annotations within ope…

### DIFF
--- a/plugins/org.jboss.tools.windup.model/src/org/jboss/tools/windup/model/domain/WindupConstants.java
+++ b/plugins/org.jboss.tools.windup.model/src/org/jboss/tools/windup/model/domain/WindupConstants.java
@@ -42,11 +42,15 @@ public interface WindupConstants {
 	 */
 	String ACTIVE_CONFIG = "windup/config/selected";
 	String SYNCH = "windup/config/synch";
+	String MARKER_DELETED = "windup/issues/deleted";
 	String MARKERS_CHANGED = "windup/issue/markers";
 	String GROUPS_CHANGED = "windup/issue/groups";
 	String INPUT_CHANGED = "windup/configuration/input";
 	String ISSUE_CHANGED = "windup/issues/changed";
+	String ISSUE_STALE = "windup/issues/stale";
+	
 	String EVENT_ISSUE_MARKER = "data";
+	String EVENT_ISSUE_MARKER_UPDATE = "dataUpdate";
 	
 	/**
 	 * Model Events

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/IssueExplorerContentProvider.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/IssueExplorerContentProvider.java
@@ -13,8 +13,6 @@ package org.jboss.tools.windup.ui.internal.explorer;
 import static org.jboss.tools.windup.model.domain.WindupMarker.SEVERITY;
 
 import java.io.File;
-import java.util.Dictionary;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -227,12 +225,6 @@ public class IssueExplorerContentProvider implements ICommonContentProvider {
 		public void addChild(TreeNode node) {
 			node.parent = this;
 			children.put(node.segment, node);
-		}
-		
-		protected Dictionary<String, Object> createData() {
-			Dictionary<String, Object> props = new Hashtable<String, Object>();
-			props.put(WindupConstants.EVENT_ISSUE_MARKER, this);
-			return props;
 		}
 		
 		public boolean isLeafParent() {

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/IssueExplorerHandlers.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/IssueExplorerHandlers.java
@@ -12,6 +12,9 @@ package org.jboss.tools.windup.ui.internal.explorer;
 
 import static org.jboss.tools.windup.model.domain.WindupConstants.MARKERS_CHANGED;
 
+import java.util.Dictionary;
+import java.util.Hashtable;
+
 import javax.inject.Inject;
 
 import org.eclipse.core.commands.AbstractHandler;
@@ -216,8 +219,10 @@ public class IssueExplorerHandlers {
 			TreeSelection selection = (TreeSelection) HandlerUtil.getCurrentSelection(event);
 			for (Object selected : ((StructuredSelection)selection).toList()) {
 				((MarkerNode)selected).delete();
+				Dictionary<String, Object> props = new Hashtable<String, Object>();
+				props.put(WindupConstants.EVENT_ISSUE_MARKER, selected);
+				broker.send(WindupConstants.MARKER_DELETED, props);
 			}
-			broker.send(WindupConstants.MARKERS_CHANGED, true);
 			return null;
 		}
 	}

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/IssueExplorerLabelProvider.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/IssueExplorerLabelProvider.java
@@ -103,23 +103,30 @@ public class IssueExplorerLabelProvider implements ICommonLabelProvider, IStyled
 		}
 		if (element instanceof MarkerNode) {
 			MarkerNode issue = (MarkerNode)element;
+			
+			boolean isFixed = issue.isFixed();
+			if (isFixed) {
+				return FIXED;
+			}
+			
 			if (issue.getIssue().isStale()) {
 				return STALE;
 			}
+		
 			boolean hasQuickFix = issue.hasQuickFix();
-			boolean isFixed = issue.isFixed();
+			
 			Image result = null;
 			switch (issue.getSeverity()) {
 				case IMarker.SEVERITY_ERROR: {
-					result = isFixed ? FIXED : hasQuickFix ? ERROR_QUICKFIX : ERROR;
+					result = hasQuickFix ? ERROR_QUICKFIX : ERROR;
 					break;
 				}
 				case IMarker.SEVERITY_WARNING: {
-					result = isFixed ? FIXED : hasQuickFix ? WARNING_QUICKFIX : WARNING;
+					result = hasQuickFix ? WARNING_QUICKFIX : WARNING;
 					break;
 				}
 				default: {
-					result = isFixed ? FIXED : hasQuickFix ? INFO_QUICKFIX : INFO;
+					result = hasQuickFix ? INFO_QUICKFIX : INFO;
 				}
 			}
 			return result;

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/MarkerNode.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/MarkerNode.java
@@ -14,6 +14,9 @@ import static org.jboss.tools.windup.model.domain.WindupMarker.SEVERITY;
 import static org.jboss.tools.windup.ui.internal.Messages.issueDeleteError;
 import static org.jboss.tools.windup.ui.internal.Messages.operationError;
 
+import java.util.Dictionary;
+import java.util.Hashtable;
+
 import javax.inject.Inject;
 
 import org.eclipse.core.resources.IMarker;
@@ -44,6 +47,10 @@ public class MarkerNode extends TreeNode {
 		super (marker);
 		this.marker = marker;
 		this.issue = modelService.findIssue(marker);
+	}
+	
+	public void setMarker(IMarker marker) {
+		this.marker = marker;
 	}
 	
 	public String getTitle() {
@@ -84,7 +91,9 @@ public class MarkerNode extends TreeNode {
 		} catch (CoreException e) {
 			WindupUIPlugin.log(e);
 		}
-		broker.post(WindupConstants.ISSUE_CHANGED, createData());
+		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		props.put(WindupConstants.EVENT_ISSUE_MARKER, marker);
+		broker.post(WindupConstants.ISSUE_CHANGED, props);
 	}
 	
 	public boolean isFixed() {

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/services/MarkerService.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/services/MarkerService.java
@@ -133,12 +133,22 @@ public class MarkerService {
 		}
 	}
 	
+	public static IMarker createMarker(Issue issue, IResource resource) {
+		String type = issue instanceof Classification ? WINDUP_CLASSIFICATION_MARKER_ID : WINDUP_HINT_MARKER_ID;
+		try {
+			return resource.createMarker(type);
+		} catch (CoreException e) {
+			WindupUIPlugin.log(e);
+		}
+		return null;
+	}
+	
 	/**
 	 * Helper method that actually creates the marker on the specified resource for the specified Windup migration issue.
 	 */
 	private void createWindupMarker(Issue issue, ConfigurationElement configuration, IResource resource) throws CoreException {
-		String type = issue instanceof Classification ? WINDUP_CLASSIFICATION_MARKER_ID : WINDUP_HINT_MARKER_ID;
-		IMarker marker = resource.createMarker(type);
+	
+		IMarker marker = createMarker(issue, resource);
 		marker.setAttribute(CONFIGURATION_ID, configuration.getName());
 		
 		IJavaElement element = JavaCore.create(resource);


### PR DESCRIPTION
…n source editors when a migration issue has become stale. Fixed refresh issue from within Issue Explorer when an issue is marked as fixed and the tree not updating the image.