### PR TITLE
Update default migration path text in Getting Started View

### DIFF
--- a/plugins/org.jboss.tools.windup.ui/html/windup.html
+++ b/plugins/org.jboss.tools.windup.ui/html/windup.html
@@ -38,8 +38,7 @@
         </li>
         <li>
           <p>
-            <a 
-               ="#review-issues">Review Windup issues</a> listed in the Issue Explorer.
+            <a href="#review-issues">Review Windup issues</a> listed in the Issue Explorer.
           </p>
         </li>
         <li>

--- a/plugins/org.jboss.tools.windup.ui/html/windup.html
+++ b/plugins/org.jboss.tools.windup.ui/html/windup.html
@@ -38,7 +38,8 @@
         </li>
         <li>
           <p>
-            <a href="#review-issues">Review Windup issues</a> listed in the Issue Explorer.
+            <a 
+               ="#review-issues">Review Windup issues</a> listed in the Issue Explorer.
           </p>
         </li>
         <li>
@@ -61,7 +62,7 @@
       </p>
       <h4>Input</h4>
       <p>
-        Select a <b>migration path</b>. This determines which Windup rulesets are used. The migration path defaults to <b>Anything to EAP 7</b>, but can target <b>EAP 6</b> or specify a particular source.
+        Select a <b>migration path</b>. This determines which Windup rulesets are used. The migration path defaults to <b>EAP 6 to EAP 7</b>, but can be changed to <a href="https://access.redhat.com/documentation/en/red-hat-jboss-migration-toolkit/2.7/single/windup-user-guide#migration_paths">any supported migration path</a>.
       </p>
       <p>
         Select one or more <b>projects</b> to analyze. Hold the <b>Ctrl</b> key to select multiple projects in the list.


### PR DESCRIPTION
-- Mention default path is EAP 6 to 7
-- Add link to migration paths section of Windup User Guide