### PR TITLE
WINDUP-1262 - Fix for separating out how windup is ran after the wind…

### DIFF
--- a/plugins/org.jboss.tools.windup.runtime/src/org/jboss/tools/windup/runtime/WindupRmiClient.java
+++ b/plugins/org.jboss.tools.windup.runtime/src/org/jboss/tools/windup/runtime/WindupRmiClient.java
@@ -52,6 +52,10 @@ public class WindupRmiClient {
 		this.rmiPort = 1100;
 		this.windupHome = WindupRuntimePlugin.findWindupHome().toPath().resolve("bin").resolve("windup");
 	}
+	
+	public Path getWindupHome() {
+		return windupHome;
+	}
 
 	public void startWindup(final IProgressMonitor monitor, final ProgressCallback callback) {
 		monitor.worked(1);
@@ -110,6 +114,7 @@ public class WindupRmiClient {
 		try {
 			Registry registry = LocateRegistry.getRegistry(rmiPort);
 	        ExecutionBuilder executionBuilder = (ExecutionBuilder) registry.lookup(ExecutionBuilder.LOOKUP_NAME);
+	        // TODO: Waiting for WINDUP-1259 executionBuilder.clear();
 	        return executionBuilder;
 		} catch (RemoteException | NotBoundException e) {
 			e.printStackTrace();

--- a/plugins/org.jboss.tools.windup.runtime/src/org/jboss/tools/windup/runtime/WindupRuntimePlugin.java
+++ b/plugins/org.jboss.tools.windup.runtime/src/org/jboss/tools/windup/runtime/WindupRuntimePlugin.java
@@ -150,7 +150,9 @@ public class WindupRuntimePlugin extends Plugin
     }
     
 	public static void log(IStatus status) {
-		WindupRuntimePlugin.getDefault().getLog().log(status);
+		if (WindupRuntimePlugin.getDefault() != null) {
+			WindupRuntimePlugin.getDefault().getLog().log(status);
+		}
 	}
 
 	public static void logErrorMessage(final String message) {

--- a/plugins/org.jboss.tools.windup.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.windup.ui/META-INF/MANIFEST.MF
@@ -64,4 +64,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.windup.ui,
  org.jboss.tools.windup.ui.internal.explorer,
- org.jboss.tools.windup.ui.internal.services
+ org.jboss.tools.windup.ui.internal.services,
+ org.jboss.tools.windup.ui.util

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/Messages.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/Messages.java
@@ -27,6 +27,9 @@ public class Messages extends NLS
 	public static String WindupStartingDetail;
 	public static String WindupStartingError;
 	public static String WindupServerError;
+	
+	public static String WindupNotExecutableTitle;
+	public static String WindupNotExecutableInfo;
 
     public static String refresh;
 

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/launch/WindupLaunchDelegate.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/launch/WindupLaunchDelegate.java
@@ -13,18 +13,11 @@ package org.jboss.tools.windup.ui.internal.launch;
 
 import static org.jboss.tools.windup.model.domain.WindupConstants.LAUNCH_COMPLETED;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -37,29 +30,23 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.jboss.tools.windup.core.services.WindupService;
 import org.jboss.tools.windup.model.domain.ModelService;
-import org.jboss.tools.windup.runtime.WindupRmiClient;
-import org.jboss.tools.windup.runtime.WindupRmiClient.ProgressCallback;
-import org.jboss.tools.windup.ui.WindupUIPlugin;
 import org.jboss.tools.windup.ui.internal.Messages;
-import org.jboss.tools.windup.ui.internal.services.ConsoleService;
 import org.jboss.tools.windup.ui.internal.services.MarkerService;
-import org.jboss.tools.windup.ui.util.FutureUtils;
-import org.jboss.tools.windup.ui.util.FutureUtils.AbstractDelegatingMonitorJob;
+import org.jboss.tools.windup.ui.util.WindupLauncher;
 import org.jboss.tools.windup.windup.ConfigurationElement;
+
 
 /**
  * The launch delegate for Windup.
  */
 public class WindupLaunchDelegate implements ILaunchConfigurationDelegate {
 	
-	public static final long WINDUP_START_DURATION_TIMEOUT = 15000;
+	@Inject private WindupLauncher launcher;
 	
-	@Inject private ModelService modelService;
 	@Inject private WindupService windupService;
 	@Inject private IEventBroker broker;
+	@Inject private ModelService modelService;
 	@Inject private MarkerService markerService;
-	@Inject private ConsoleService consoleService;
-	@Inject private WindupRmiClient windupClient;
 	@Inject @Named (IServiceConstants.ACTIVE_SHELL) Shell shell;
 	
 	public void launch(ILaunchConfiguration config, String mode, ILaunch launch, IProgressMonitor monitor) {
@@ -72,100 +59,8 @@ public class WindupLaunchDelegate implements ILaunchConfigurationDelegate {
 		}
 		else {
 			markerService.deleteAllWindupMarkers();
-			if (!windupClient.isWindupServerRunning()) {
-				startWindup(configuration);
-			}
-			else {
-				runWindup(configuration);
-			}
+			launcher.launchWindup(configuration, this::runWindup);
 		}
-	}
-	
-	private void startWindup(ConfigurationElement configuration) {
-		WindupRmiClient.ProgressCallback callback = new WindupRmiClient.ProgressCallback() {
-			private boolean serverStarted = false;
-			@Override
-			public void serverStarted() {
-				serverStarted = true;
-			}
-			@Override
-			public boolean isServerStarted() {
-				return serverStarted;
-			}
-			@Override
-			public void log(String line) {
-				consoleService.write(line);
-			}
-			@Override
-			public void processFailed(String message) {
-				Display.getDefault().asyncExec(() -> {
-					MessageDialog.openError(shell, Messages.WindupServerError, message);
-				});
-			}
-		};
-
-		Job job = createStartWindupJob(callback);
-		Display.getDefault().syncExec(() -> {
-			IStatus status = FutureUtils.runWithProgress(job, WINDUP_START_DURATION_TIMEOUT, 7, shell, Messages.WindupStartingDetail);
-			if (status.isOK()) {
-				runWindup(configuration);
-			}
-			else {
-				WindupLaunchDelegate.openError(shell, status.getMessage());
-			}
-		});
-	}
-	
-	public Job createStartWindupJob(final ProgressCallback callback) {
-		Job job = new AbstractDelegatingMonitorJob(Messages.WindupStartingTitle) {
-			@Override
-			protected IStatus doRun(IProgressMonitor monitor) {
-				Future<IStatus> future = new Future<IStatus>() {
-					private AtomicBoolean cancelled = new AtomicBoolean(false);
-					@Override
-					public boolean cancel(boolean mayInterruptIfRunning) {
-						cancelled.set(true);
-						return true;
-					}
-					@Override
-					public boolean isCancelled() {
-						return cancelled.get();
-					}
-					@Override
-					public boolean isDone() {
-						return callback.isServerStarted();
-					}
-					@Override
-					public IStatus get() throws InterruptedException, ExecutionException {
-						return null;
-					}
-					@Override
-					public IStatus get(long timeout, TimeUnit unit)
-							throws InterruptedException, ExecutionException, TimeoutException {
-						return null;
-					}
-				};
-				windupClient.startWindup(monitor, callback);
-				try {
-					FutureUtils.waitForFuture(WINDUP_START_DURATION_TIMEOUT, future, monitor);
-				} catch (ExecutionException | TimeoutException | InterruptedException e) {
-					WindupUIPlugin.log(e);
-					WindupLaunchDelegate.openError(shell, e.getMessage());
-				} finally {
-					monitor.done();
-				}
-				return Status.OK_STATUS;
-			}
-		};
-		job.setUser(true);
-		return job;
-	}
-	
-	private static void openError(Shell shell, String message) {
-		Display.getDefault().asyncExec(() -> {
-			String msg = Messages.WindupStartingError + " " + message;
-			MessageDialog.openError(shell,  Messages.WindupServerError, msg);
-		});
 	}
 	
 	private void runWindup(ConfigurationElement configuration) {

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/messages.properties
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/messages.properties
@@ -16,6 +16,9 @@ WindupStartingDetail=Windup is being started in server mode.
 WindupStartingError=Error occurred while trying to start Windup in server mode.
 WindupServerError=Windup Server Process Terminated
 
+WindupNotExecutableTitle=Error while running Windup
+WindupNotExecutableInfo=The Windup script is not executable.
+
 showWindupGettingStarted=Show getting started with Windup
 
 showInIssueExplorer=Show Issue in Issue Explorer

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/util/WindupLauncher.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/util/WindupLauncher.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.windup.ui.util;
+
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.e4.core.di.annotations.Creatable;
+import org.eclipse.e4.ui.services.IServiceConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.jboss.tools.windup.runtime.WindupRmiClient;
+import org.jboss.tools.windup.runtime.WindupRmiClient.ProgressCallback;
+import org.jboss.tools.windup.ui.WindupUIPlugin;
+import org.jboss.tools.windup.ui.internal.Messages;
+import org.jboss.tools.windup.ui.internal.services.ConsoleService;
+import org.jboss.tools.windup.ui.internal.services.MarkerService;
+import org.jboss.tools.windup.ui.util.FutureUtils.AbstractDelegatingMonitorJob;
+import org.jboss.tools.windup.windup.ConfigurationElement;
+
+@Singleton
+@Creatable
+public class WindupLauncher {
+	
+	// TODO: Move to preference item.
+	public static final long WINDUP_START_DURATION_TIMEOUT = 15000;
+
+	@Inject private MarkerService markerService;
+	@Inject private ConsoleService consoleService;
+	@Inject private WindupRmiClient windupClient;
+	@Inject @Named (IServiceConstants.ACTIVE_SHELL) Shell shell;
+
+	public void launchWindup(ConfigurationElement configuration, Consumer<ConfigurationElement> windupStartedCallback) {
+		markerService.deleteAllWindupMarkers();
+		if (!windupClient.isWindupServerRunning()) {
+			String windupHome = windupClient.getWindupHome().toString();
+			boolean executable = new File(windupHome).setExecutable(true);
+			if (executable) {
+				startWindup(configuration, windupStartedCallback);
+			}
+			else {
+				WindupUIPlugin.logErrorMessage(Messages.WindupNotExecutableInfo);
+				String message = Messages.WindupNotExecutableInfo + " - " + windupHome;
+				MessageDialog.openError(shell, Messages.WindupNotExecutableTitle, message);
+			}
+		}
+		else {
+			windupStartedCallback.accept(configuration);
+		}
+	}
+	
+	private void startWindup(ConfigurationElement configuration, Consumer<ConfigurationElement> windupStartedCallback) {
+		WindupRmiClient.ProgressCallback callback = new WindupRmiClient.ProgressCallback() {
+			private boolean serverStarted = false;
+			@Override
+			public void serverStarted() {
+				serverStarted = true;
+			}
+			@Override
+			public boolean isServerStarted() {
+				return serverStarted;
+			}
+			@Override
+			public void log(String line) {
+				consoleService.write(line);
+			}
+			@Override
+			public void processFailed(String message) {
+				Display.getDefault().asyncExec(() -> {
+					MessageDialog.openError(shell, Messages.WindupServerError, message);
+				});
+			}
+		};
+
+		Job job = createStartWindupJob(callback);
+		Display.getDefault().syncExec(() -> {
+			IStatus status = FutureUtils.runWithProgress(job, WINDUP_START_DURATION_TIMEOUT, 7, shell, Messages.WindupStartingDetail);
+			if (status.isOK()) {
+				windupStartedCallback.accept(configuration);
+			}
+			else {
+				WindupLauncher.openError(shell, status.getMessage());
+			}
+		});
+	}
+	
+	public Job createStartWindupJob(final ProgressCallback callback) {
+		Job job = new AbstractDelegatingMonitorJob(Messages.WindupStartingTitle) {
+			@Override
+			protected IStatus doRun(IProgressMonitor monitor) {
+				Future<IStatus> future = new Future<IStatus>() {
+					private AtomicBoolean cancelled = new AtomicBoolean(false);
+					@Override
+					public boolean cancel(boolean mayInterruptIfRunning) {
+						cancelled.set(true);
+						return true;
+					}
+					@Override
+					public boolean isCancelled() {
+						return cancelled.get();
+					}
+					@Override
+					public boolean isDone() {
+						return callback.isServerStarted();
+					}
+					@Override
+					public IStatus get() throws InterruptedException, ExecutionException {
+						return null;
+					}
+					@Override
+					public IStatus get(long timeout, TimeUnit unit)
+							throws InterruptedException, ExecutionException, TimeoutException {
+						return null;
+					}
+				};
+				windupClient.startWindup(monitor, callback);
+				try {
+					FutureUtils.waitForFuture(WINDUP_START_DURATION_TIMEOUT, future, monitor);
+				} catch (ExecutionException | TimeoutException | InterruptedException e) {
+					WindupUIPlugin.log(e);
+					WindupLauncher.openError(shell, e.getMessage());
+				} finally {
+					monitor.done();
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		job.setUser(true);
+		return job;
+	}
+	
+	private static void openError(Shell shell, String message) {
+		Display.getDefault().asyncExec(() -> {
+			String msg = Messages.WindupStartingError + " " + message;
+			MessageDialog.openError(shell,  Messages.WindupServerError, msg);
+		});
+	}
+}

--- a/tests/org.jboss.tools.windup.ui.tests/src/org/jboss/tools/windup/ui/tests/WindupUiTest.java
+++ b/tests/org.jboss.tools.windup.ui.tests/src/org/jboss/tools/windup/ui/tests/WindupUiTest.java
@@ -32,6 +32,7 @@ import org.jboss.tools.windup.ui.WindupPerspective;
 import org.jboss.tools.windup.ui.internal.explorer.IssueExplorer;
 import org.jboss.tools.windup.ui.internal.services.MarkerService;
 import org.jboss.tools.windup.ui.tests.swtbot.WorkbenchBot;
+import org.jboss.tools.windup.ui.util.WindupLauncher;
 import org.jboss.tools.windup.windup.ConfigurationElement;
 import org.junit.After;
 import org.junit.Before;
@@ -60,6 +61,8 @@ public class WindupUiTest extends WindupTest {
 	@Inject protected IEventBroker broker;
 	@Inject protected MarkerService markerService;
 	
+	@Inject protected WindupLauncher windupLauncher;
+	
 	@Before
 	public void init() throws CoreException {
 		projectProvider = workbenchBot.importProject(Activator.PLUGIN_ID, null, PROJECT, false);
@@ -81,7 +84,9 @@ public class WindupUiTest extends WindupTest {
 	}
 	
 	protected void runWindup(ConfigurationElement configuration) {
-		windupService.generateGraph(configuration, new NullProgressMonitor());
+		windupLauncher.launchWindup(configuration, (config) -> {
+			windupService.generateGraph(configuration, new NullProgressMonitor());
+		});
 		Display.getDefault().syncExec(() -> {
 			try {
 				markerService.createWindupMarkers(configuration, new NullProgressMonitor());


### PR DESCRIPTION
…up server has been started. In tests, windup should not be ran in a separate threaded-job. Also, fix for setting bin/windup to executable prior to running it and preventing a permission exception.