### PR TITLE
bump plugin / feature versions to 4.0

### DIFF
--- a/features/org.jboss.tools.windup.feature/feature.xml
+++ b/features/org.jboss.tools.windup.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.windup.feature"
       label="%featureName"
-      version="3.0.0.qualifier"
+      version="4.0.0.qualifier"
       plugin="org.jboss.tools.windup.ui"
       license-feature="org.jboss.tools.foundation.license.feature"
       provider-name="%providerName"

--- a/features/org.jboss.tools.windup.feature/pom.xml
+++ b/features/org.jboss.tools.windup.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.windup</groupId>
 		<artifactId>features</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.windup.features</groupId>
 	<artifactId>org.jboss.tools.windup.feature</artifactId> 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>windup</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jboss.tools.windup</groupId>

--- a/plugins/org.jboss.tools.windup.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.windup.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.jboss.tools.windup.core;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.jboss.tools.windup.core.WindupCorePlugin
 Bundle-Vendor: %plugin.vendor

--- a/plugins/org.jboss.tools.windup.core/pom.xml
+++ b/plugins/org.jboss.tools.windup.core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.windup</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.windup.plugins</groupId>

--- a/plugins/org.jboss.tools.windup.model.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.windup.model.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.jboss.tools.windup.model.edit;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.jboss.tools.windup.model.edit.domain.WindupEditPlugin
 Bundle-Vendor: %providerName

--- a/plugins/org.jboss.tools.windup.model.edit/pom.xml
+++ b/plugins/org.jboss.tools.windup.model.edit/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.windup</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.windup.plugins</groupId>

--- a/plugins/org.jboss.tools.windup.model.editor/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.windup.model.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.jboss.tools.windup.model.editor;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.jboss.tools.windup.windup.presentation.WindupEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/plugins/org.jboss.tools.windup.model.editor/pom.xml
+++ b/plugins/org.jboss.tools.windup.model.editor/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.windup</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.windup.plugins</groupId>

--- a/plugins/org.jboss.tools.windup.model/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.windup.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Model
 Bundle-SymbolicName: org.jboss.tools.windup.model;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.jboss.tools.windup.model.Activator
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.tools.windup.model/pom.xml
+++ b/plugins/org.jboss.tools.windup.model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.windup</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.windup.plugins</groupId>

--- a/plugins/org.jboss.tools.windup.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.windup.runtime/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.jboss.tools.windup.runtime;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.jboss.tools.windup.runtime.WindupRuntimePlugin
 Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.core.runtime,

--- a/plugins/org.jboss.tools.windup.runtime/pom.xml
+++ b/plugins/org.jboss.tools.windup.runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss.tools.windup</groupId>
         <artifactId>plugins</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.tools.windup.plugins</groupId>

--- a/plugins/org.jboss.tools.windup.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.windup.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.jboss.tools.windup.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Eclipse-BundleShape: dir
 Bundle-ClassPath: .
 Bundle-Activator: org.jboss.tools.windup.ui.WindupUIPlugin
@@ -10,7 +10,7 @@ Bundle-Vendor: %plugin.vendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.tools.windup.core;bundle-version="[3.0.0,4.0.0)",
+ org.jboss.tools.windup.core;bundle-version="[4.0.0,5.0.0)",
  org.eclipse.ui.browser;bundle-version="[3.4.2,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.8.1,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.8.2,4.0.0)",

--- a/plugins/org.jboss.tools.windup.ui/pom.xml
+++ b/plugins/org.jboss.tools.windup.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.windup</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.windup.plugins</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>windup</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jboss.tools.windup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>windup</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <name>windup.all</name>
 
     <packaging>pom</packaging>
@@ -24,6 +24,9 @@
     <properties>
         <windup.version>3.0.0-SNAPSHOT</windup.version>
         <tycho.scmUrl>scm:git:https://github.com/windup/windup-eclipse-plugin.git</tycho.scmUrl>
+        <!-- exclude variables that are allowed to have SNAPSHOT versions
+        See https://github.com/jbosstools/jbosstools-devdoc/blob/master/source/build_checks.adoc#enforce-no-snapshots-final -->
+        <enforceExcludePatternExtras>|windup.version</enforceExcludePatternExtras>
     </properties>
 
     <dependencyManagement>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>windup</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.windup</groupId>
 	<artifactId>windup.site</artifactId>

--- a/tests/org.jboss.tools.windup.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.windup.core.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.jboss.tools.windup.core.test;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.jboss.tools.windup.core.test.WindupCoreTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.wst.validation;bundle-version="[1.2.402,2.0.0)",
  org.junit;bundle-version="[4.8.2,5.0.0)",
- org.jboss.tools.windup.core;bundle-version="[3.0.0,4.0.0)",
+ org.jboss.tools.windup.core;bundle-version="[4.0.0,5.0.0)",
  org.apache.commons.io;bundle-version="[2.0.1,3.0.0)",
  com.google.inject,
  org.eclipse.e4.core.contexts,

--- a/tests/org.jboss.tools.windup.core.test/pom.xml
+++ b/tests/org.jboss.tools.windup.core.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.windup</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	
 	<groupId>org.jboss.tools.windup.tests</groupId>

--- a/tests/org.jboss.tools.windup.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.windup.ui.tests/META-INF/MANIFEST.MF
@@ -3,14 +3,14 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.jboss.tools.windup.ui.tests;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.wst.validation;bundle-version="[1.2.402,2.0.0)",
  org.junit;bundle-version="[4.8.2,5.0.0)",
- org.jboss.tools.windup.core;bundle-version="[3.0.0,4.0.0)",
+ org.jboss.tools.windup.core;bundle-version="[4.0.0,5.0.0)",
  org.apache.commons.io;bundle-version="[2.0.1,3.0.0)",
  com.google.inject,
  org.eclipse.e4.core.contexts,

--- a/tests/org.jboss.tools.windup.ui.tests/pom.xml
+++ b/tests/org.jboss.tools.windup.ui.tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.windup</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.windup.tests</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>windup</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.windup</groupId>


### PR DESCRIPTION
bump plugin and feature versions to 4.0.0, including fixing Require-Bundle on org.jboss.tools.windup.core to [4.0.0,5.0.0)
Signed-off-by: nickboldt <nboldt@redhat.com>