### PR TITLE
Resolved issue with mouse exit events fired from labels not already h…

### DIFF
--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/rules/delegate/ControlInformationSupport.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/rules/delegate/ControlInformationSupport.java
@@ -179,9 +179,10 @@ public class ControlInformationSupport {
 			control.addMouseTrackListener(new MouseTrackListener() {
 				@Override
 				public void mouseHover(MouseEvent e) {
+					// stupid MouseTracker doesn't get deactivated once replacement takes hover and mouse e
 					IInformationControl iControl = getInformationControl();
 					if (iControl != null && iControl instanceof IInformationControlExtension5) {
-						if (!((IInformationControlExtension5)iControl).isVisible()) {
+						if (!((IInformationControlExtension5)iControl).isVisible() && Display.getCurrent().getActiveShell() == control.getShell()) {
 							showInformation();
 						}
 					}


### PR DESCRIPTION
…aving shown their information control while another information control is currently visilbe resulting in an NPE. This might also happen if an info control is not visible. The result of this patch is, however, that the replacing hover control will be hidden on mouse move events outside of the bounds b/c there's no other way to force each info controls' closer to have the subjectArea pre-set.