### PR TITLE
WINDUP-1662 to avoid cluttering nexus, must...

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -14,6 +14,7 @@
 
 	<properties>
 		<update.site.name>JBoss Tools - Windup</update.site.name>
+		<skipDeployToJBossOrg>true</skipDeployToJBossOrg>
 	</properties>
 
 	<profiles>


### PR DESCRIPTION
WINDUP-1662 to avoid cluttering nexus, must now use skipDeployToJBossOrg=true in the site pom

Signed-off-by: nickboldt <nboldt@redhat.com>