### PR TITLE
Use empty string in the event a quickfix replacement string is null. …

### DIFF
--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/QuickfixService.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/explorer/QuickfixService.java
@@ -123,6 +123,7 @@ public class QuickfixService {
 			String searchString = quickFix.getSearchString();
 			String replacement = quickFix.getReplacementString();
 			if (document != null) {
+				replacement = replacement != null ? replacement : "";
 				DocumentUtils.replace(document, lineNumber, searchString, replacement);
 				return marker.getResource();
 			}

--- a/tests/org.jboss.tools.windup.ui.tests/src/org/jboss/tools/windup/ui/tests/MarkerSyncServiceTest.java
+++ b/tests/org.jboss.tools.windup.ui.tests/src/org/jboss/tools/windup/ui/tests/MarkerSyncServiceTest.java
@@ -49,7 +49,7 @@ public class MarkerSyncServiceTest extends WindupUiTest {
 		QuickFix quickFix = hint.getQuickFixes().get(0);
 		IMarker marker = (IMarker)hint.getMarker();
 		IResource original = marker.getResource();
-		IResource newResource = quickfixService.getQuickFixedResource(quickFix, marker);
+		IResource newResource = quickfixService.getQuickFixedResource(null, quickFix, marker);
 		DocumentUtils.replace(original, newResource);
 		try {
 			ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null);


### PR DESCRIPTION
…Update test to not use existing document.