### PR TITLE
WINDUP-2043: Point to next release version of rules development guide

### DIFF
--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/editor/RulesetEditorDocumentationPage.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/editor/RulesetEditorDocumentationPage.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.widgets.Control;
 
 public class RulesetEditorDocumentationPage {
 	
-	private static final String URL = "https://access.redhat.com/documentation/en-us/red_hat_application_migration_toolkit/4.0.beta2/html-single/rules_development_guide/";
+	private static final String URL = "https://access.redhat.com/documentation/en-us/red_hat_application_migration_toolkit/4.1/html-single/rules_development_guide/";
 
 	private Browser browser;
 	

--- a/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/editor/RulesetExamplesPage.java
+++ b/plugins/org.jboss.tools.windup.ui/src/org/jboss/tools/windup/ui/internal/editor/RulesetExamplesPage.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.widgets.Control;
 
 public class RulesetExamplesPage {
 	
-	private static final String URL = "https://access.redhat.com/documentation/en-us/red_hat_application_migration_toolkit/4.0.beta2/html-single/rules_development_guide/";
+	private static final String URL = "https://access.redhat.com/documentation/en-us/red_hat_application_migration_toolkit/4.1/html-single/rules_development_guide/";
 
 	private Browser browser;
 


### PR DESCRIPTION
@johnsteele this should fix WINDUP-2043 once the documentation is released.
However it doesn't seem very convenient to change the version in the code everytime the version gets bumped.
We could replace it with a property instead form the pom maybe? Surely there are other and more elegant solutions. What do you think?